### PR TITLE
Widget/section header

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,10 @@
-
-
 import 'package:flutter/material.dart';
-
 
 import 'package:provider/provider.dart';
 import 'package:toastification/toastification.dart';
 
 import 'router.dart';
 import 'providers.dart';
-
 
 void main() {
   runApp(MyApp());

--- a/lib/widgets/custom_section_header.dart
+++ b/lib/widgets/custom_section_header.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+/// A custom header widget that can be used as an AppBar.
+///
+/// This widget implements [PreferredSizeWidget] to work seamlessly with
+/// Scaffold's appBar property. It provides a flexible header with optional
+/// back button, title, action text, and trailing widget.
+///
+/// Example usage:
+/// ```dart
+/// CustomSectionHeader(
+///   height: 100,
+///   autoImplyLeading: true,
+///   title: "Home",
+///   actionText: "Next",
+///   onActionTap: () => print("Action tapped"),
+///   trailingWidget: CircleAvatar(backgroundColor: Colors.blue),
+/// )
+/// ```
+class CustomSectionHeader extends StatelessWidget
+    implements PreferredSizeWidget {
+  /// The height of the header.
+  ///
+  /// This value is used by [preferredSize] to define the header's height
+  /// when used as an AppBar.
+  final double height;
+
+  /// Optional widget to display on the trailing (right) end of the header.
+  ///
+  /// Commonly used for profile avatars, icons, or other action widgets.
+  final Widget? trailingWidget;
+
+  /// The main title text to display in the header.
+  ///
+  /// This text is displayed with a large, bold font (size 32, weight 900).
+  final String title;
+
+  /// Optional action text to display before the trailing widget.
+  ///
+  /// When provided along with [onActionTap], creates a tappable text element.
+  /// The text appears in grey with medium weight (600).
+  final String? actionText;
+
+  /// Callback function invoked when the action text is tapped.
+  ///
+  /// This callback is only used when [actionText] is also provided.
+  /// Both [actionText] and [onActionTap] must be non-null for the
+  /// action text to be displayed.
+  final Function()? onActionTap;
+
+  /// Whether to automatically show a back button on the leading (left) side.
+  ///
+  /// When `true`, displays an iOS-style back button that calls
+  /// `Navigator.of(context).pop()` when pressed.
+  final bool autoImplyLeading;
+
+  /// Creates a [CustomSectionHeader] widget.
+  ///
+  /// The [height], [autoImplyLeading], and [title] parameters are required.
+  /// The [trailingWidget], [actionText], and [onActionTap] parameters are optional.
+
+  const CustomSectionHeader({
+    super.key,
+    required this.height,
+    required this.autoImplyLeading,
+    required this.title,
+    this.trailingWidget,
+    this.actionText,
+    this.onActionTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      // SafeArea ensures content doesn't overlap with system UI elements
+      // such as notches, status bars, or navigation bars
+      child: Padding(
+        // Add padding only on the right side for consistent spacing
+        padding: EdgeInsets.only(right: 15),
+        child: Row(
+          children: [
+            // Conditionally display back button if autoImplyLeading is true
+            if (autoImplyLeading)
+              IconButton(
+                icon: Icon(Icons.arrow_back_ios_new_rounded),
+                // Navigate back to the previous screen when pressed
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+
+            // Small horizontal spacing after the back button
+            SizedBox(width: 8),
+
+            // Display the main title with large, bold text
+            Text(
+              title,
+              style: TextStyle(fontSize: 32, fontWeight: FontWeight.w900),
+            ),
+
+            // Spacer pushes all subsequent widgets to the right side
+            Spacer(),
+
+            // Conditionally display action text if both actionText and onActionTap are provided
+            if (actionText != null && onActionTap != null) ...[
+              // Spread operator (...) allows multiple widgets in the conditional
+              GestureDetector(
+                // Call the provided callback when the action text is tapped
+                onTap: onActionTap,
+                child: Text(
+                  actionText!,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.grey,
+                  ),
+                ),
+              ),
+              // Spacing between action text and trailing widget
+              SizedBox(width: 16),
+            ],
+
+            // Conditionally display trailing widget if provided
+            if (trailingWidget != null) trailingWidget!,
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Required override for [PreferredSizeWidget].
+  ///
+  /// Returns the preferred size for this widget when used as an AppBar.
+  /// The width is unconstrained (double.infinity) and the height is
+  /// determined by the [height] parameter.
+  @override
+  Size get preferredSize => Size.fromHeight(height);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "557a315b7d2a6dbb0aaaff84d857967ce6bdc96a63dc6ee2a57ce5a6ee5d3331"
+      sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.17"
+    version: "1.1.19"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -232,15 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -353,7 +352,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0+3"
-
   petitparser:
     dependency: transitive
     description:
@@ -619,10 +617,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,34 +29,34 @@ packages:
     dependency: "direct main"
     description:
       name: camera
-      sha256: "413d2b34fe28496c35c69ede5b232fb9dd5ca2c3a4cb606b14efc1c7546cc8cb"
+      sha256: d6ec2cbdbe2fa8f5e0d07d8c06368fe4effa985a4a5ddade9cc58a8cd849557d
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.11.2"
   camera_android_camerax:
     dependency: transitive
     description:
       name: camera_android_camerax
-      sha256: b4197bd6ce75bc66963a904c34c4cbb6aaa2260a5d4aca13b3556926cf3a92b8
+      sha256: "58b8fe843a3c83fd1273c00cb35f5a8ae507f6cc9b2029bcf7e2abba499e28d8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18+3"
+    version: "0.6.19+1"
   camera_avfoundation:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: ca244564876d5a76f2126bca501aec25243cad23ba1784819242aea2fd25cf70
+      sha256: "951ef122d01ebba68b7a54bfe294e8b25585635a90465c311b2f875ae72c412f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.19+2"
+    version: "0.9.21+2"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: "2f757024a48696ff4814a789b0bd90f5660c0fb25f393ab4564fb483327930e2"
+      sha256: ea1ef6ba79cdbed93df2d3eeef11542a90dec24dbcd9cde574926b86d7a09a10
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   camera_web:
     dependency: transitive
     description:
@@ -170,10 +170,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.28"
+    version: "2.0.30"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -204,18 +204,18 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: c489908a54ce2131f1d1b7cc631af9c1a06fac5ca7c449e959192089f9489431
+      sha256: c752e2d08d088bf83742cb05bf83003f3e9d276ff1519b5c92f9d5e60e5ddd23
       url: "https://pub.dev"
     source: hosted
-    version: "16.0.0"
+    version: "16.2.4"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_parser:
     dependency: transitive
     description:
@@ -388,10 +388,10 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.5+1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -404,10 +404,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.13"
   shared_preferences_foundation:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -178,10 +178,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: cd57f7969b4679317c17af6fd16ee233c1e60a82ed209d8a475c54fd6fd6f845
+      sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -196,10 +196,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: d3a89184101baec7f4600d58840a764d2ef760fe1c5a20ef9e6b0e9b24a07a3a
+      sha256: b738e35f8bb4957896c34957baf922f99c5d415b38ddc8b070d14b7fa95715d4
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.0"
+    version: "10.9.1"
   go_router:
     dependency: "direct main"
     description:
@@ -264,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  loading_animation_widget:
+    dependency: "direct main"
+    description:
+      name: loading_animation_widget
+      sha256: "9fe23381f3096e902f39e87e487648ff7f74925e86234353fa885bb9f6c98004"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,8 +40,9 @@ dependencies:
   camera: ^0.11.1
   shared_preferences: ^2.5.3
   toastification: ^3.0.3
-  flutter_svg: ^2.2.0
-  font_awesome_flutter: ^10.8.0
+  font_awesome_flutter: ^10.9.0
+  loading_animation_widget: ^1.3.0
+  flutter_svg: ^2.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📝 Description

[feat]: Added a reusable `CustomSectionHeader` widget that can be used as a flexible AppBar with support for back button, title, action text, and trailing widget.

## ✅ Related Issue

Closes #10 

## 🔍 Changes Made

- Created `custom_section_header.dart` containing the `CustomSectionHeader` widget.  
- Implemented `PreferredSizeWidget` to allow usage in Scaffold’s `appBar`.  
- Added support for:
  - Optional back button (`autoImplyLeading`)  
  - Title text with custom style  
  - Action text with callback (`actionText` + `onActionTap`)  
  - Trailing widget (e.g., avatar, icon, etc.)  

## 📸 Screenshots 
![sectionheader1](https://github.com/user-attachments/assets/0f0873fd-304a-4c65-bdfe-b5ab029e1c21)
![sectionheader2](https://github.com/user-attachments/assets/d26e4658-7b5c-4d53-84c2-262205d59668)

## 🧪 Testing

- [x] `flutter run` works without error  
- [x] New `CustomSectionHeader` tested manually in Scaffold  
- [ ] Relevant tests added  
- [ ] Existing tests were updated (i.e is it a breaking change)?  

## 📦 Checklist

- [x] Follows code style and naming conventions  
- [x] PR linked to a GitHub issue  
