### PR TITLE
Persist theme and language via SharedPreferencesProvider (#3)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,7 @@ class MyApp extends StatelessWidget {
               ),
 
               // Optional language binding (expand when you localize)
-              locale: Locale(sp.preferredLanguage),
+              locale: Locale(['en'].contains(sp.preferredLanguage) ? sp.preferredLanguage : 'en'),
               supportedLocales: const [Locale('en')],
 
               routerConfig: router,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,34 +7,50 @@ import 'providers.dart';
 import 'providers/theme_provider.dart';
 import 'providers/shared_preferences_provider.dart';
 
-void main() {
-  runApp(MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Preload SharedPreferencesProvider to avoid flicker and ensure availability
+  final sharedPrefsProvider = SharedPreferencesProvider();
+  await sharedPrefsProvider.loadSettings();
+
+  runApp(MyApp(prefs: sharedPrefsProvider));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final SharedPreferencesProvider prefs;
+  const MyApp({super.key, required this.prefs});
 
   @override
   Widget build(BuildContext context) {
     return ToastificationWrapper(
-      config: ToastificationConfig(
+      config: const ToastificationConfig(
         alignment: Alignment.bottomCenter,
         maxToastLimit: 1,
       ),
       child: MultiProvider(
-        providers: providers,
+        providers: [
+          // Provide preloaded SharedPreferencesProvider first so others can depend on it
+          ChangeNotifierProvider<SharedPreferencesProvider>.value(value: prefs),
+          ...providers, // Auth, Db, Theme (proxy)
+        ],
         child: Consumer2<SharedPreferencesProvider, ThemeProvider>(
-          builder: (context, sharedPreferencesProvider, themeProvider, child) {
-            sharedPreferencesProvider.loadSettings();
+          builder: (context, sp, theme, child) {
             return MaterialApp.router(
+              debugShowCheckedModeBanner: false, // removed the DEBUG banner
               title: 'Nourish App',
-              themeMode: themeProvider.themeMode,
+              themeMode: theme.themeMode,
               theme: ThemeData.light().copyWith(
                 colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
               ),
               darkTheme: ThemeData.dark().copyWith(
                 colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
               ),
+
+              // Optional language binding (expand when you localize)
+              locale: Locale(sp.preferredLanguage),
+              supportedLocales: const [Locale('en')],
+
               routerConfig: router,
               builder: (context, child) => child!,
             );

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -2,13 +2,16 @@ import 'package:provider/provider.dart';
 
 // Global Providers
 import 'providers/auth_provider.dart';
-import 'providers/theme_provider.dart';
 import 'providers/db_provider.dart';
 import 'providers/shared_preferences_provider.dart';
+import 'providers/theme_provider.dart';
 
 final providers = [
   ChangeNotifierProvider(create: (_) => AuthProvider()),
-  ChangeNotifierProvider(create: (_) => ThemeProvider()),
   ChangeNotifierProvider(create: (_) => DbProvider()),
-  ChangeNotifierProvider(create: (_) => SharedPreferencesProvider()),
+  // ThemeProvider depends on SharedPreferencesProvider (provided in main.dart)
+  ChangeNotifierProxyProvider<SharedPreferencesProvider, ThemeProvider>(
+    create: (_) => ThemeProvider(),
+    update: (_, sp, theme) => theme!..attach(sp),
+  ),
 ];

--- a/lib/providers/shared_preferences_provider.dart
+++ b/lib/providers/shared_preferences_provider.dart
@@ -40,10 +40,12 @@ class SharedPreferencesProvider extends ChangeNotifier {
   }
 
   Future<void> setDarkMode(bool value) async {
-    _isDarkMode = value;
     final prefs = _prefs ??= await SharedPreferences.getInstance();
-    await prefs.setBool(_kIsDarkMode, value);
-    notifyListeners();
+    final success = await prefs.setBool(_kIsDarkMode, value);
+    if (success) {
+      _isDarkMode = value;
+      notifyListeners();
+    }
   }
 
   Future<void> toggleDarkMode() => setDarkMode(!_isDarkMode);

--- a/lib/providers/shared_preferences_provider.dart
+++ b/lib/providers/shared_preferences_provider.dart
@@ -57,11 +57,16 @@ class SharedPreferencesProvider extends ChangeNotifier {
 
   Future<void> reset() async {
     final prefs = _prefs ??= await SharedPreferences.getInstance();
-    await prefs.remove(_kIsDarkMode);
-    await prefs.remove(_kPreferredLanguage);
+    final darkModeRemoved = await prefs.remove(_kIsDarkMode);
+    final languageRemoved = await prefs.remove(_kPreferredLanguage);
 
-    _isDarkMode = false;
-    _preferredLanguage = 'en';
-    notifyListeners();
+    if (darkModeRemoved && languageRemoved) {
+      _isDarkMode = false;
+      _preferredLanguage = 'en';
+      notifyListeners();
+    } else {
+      // Optionally handle the error, e.g., log or throw
+      // debugPrint('Failed to reset SharedPreferences');
+    }
   }
 }

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -34,11 +34,11 @@ class ThemeProvider extends ChangeNotifier {
   Future<void> setThemeMode(ThemeMode mode) async {
     if (_themeMode == mode) return;
     _themeMode = mode;
-    notifyListeners();
 
     final sp = _sp;
     if (sp != null) {
       await sp.setDarkMode(mode == ThemeMode.dark);
     }
+    notifyListeners();
   }
 }

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -8,7 +8,13 @@ class ThemeProvider extends ChangeNotifier {
 
   ThemeMode get themeMode => _themeMode;
 
-  // Called by ProxyProvider to connect to SharedPreferencesProvider
+  /// Integrates this provider with [SharedPreferencesProvider].
+  ///
+  /// This method is invoked by [ChangeNotifierProxyProvider] whenever the
+  /// [SharedPreferencesProvider] instance changes. It connects this
+  /// [ThemeProvider] to the shared preferences provider, synchronizes the
+  /// theme mode with the value stored in shared preferences, and notifies
+  /// listeners if the theme mode changes.
   void attach(SharedPreferencesProvider sp) {
     _sp = sp;
     final modeFromPrefs = sp.isDarkMode ? ThemeMode.dark : ThemeMode.light;

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,32 +1,38 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'shared_preferences_provider.dart';
 
 class ThemeProvider extends ChangeNotifier {
-  // Default theme mode is light
   ThemeMode _themeMode = ThemeMode.light;
+  SharedPreferencesProvider? _sp;
+  bool _syncedOnce = false;
 
   ThemeMode get themeMode => _themeMode;
 
-  ThemeProvider() {
-    _loadTheme(); // Load the saved theme from SharedPreferences
-  }
+  // Called by ProxyProvider to connect to SharedPreferencesProvider
+  void attach(SharedPreferencesProvider sp) {
+    _sp = sp;
+    final modeFromPrefs = sp.isDarkMode ? ThemeMode.dark : ThemeMode.light;
 
-  // Load the theme from SharedPreferences
-  Future<void> _loadTheme() async {
-    final prefs = await SharedPreferences.getInstance();
-    final savedTheme = prefs.getString('themeMode');
-    if (savedTheme != null) {
-      _themeMode = savedTheme == 'dark' ? ThemeMode.dark : ThemeMode.light;
+    if (!_syncedOnce || modeFromPrefs != _themeMode) {
+      _syncedOnce = true;
+      _themeMode = modeFromPrefs;
+      notifyListeners();
     }
-    notifyListeners();
   }
 
-  // Toggle between light and dark mode
-  void toggleTheme() async {
-    _themeMode = _themeMode == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
-    // Save the selected theme to SharedPreferences
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('themeMode', _themeMode == ThemeMode.dark ? 'dark' : 'light');
-    notifyListeners(); // Notify listeners to rebuild with the new theme
+  Future<void> toggleTheme() async {
+    final newMode = _themeMode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
+    await setThemeMode(newMode);
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_themeMode == mode) return;
+    _themeMode = mode;
+    notifyListeners();
+
+    final sp = _sp;
+    if (sp != null) {
+      await sp.setDarkMode(mode == ThemeMode.dark);
+    }
   }
 }

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -20,10 +20,10 @@ class ThemeProvider extends ChangeNotifier {
     final modeFromPrefs = sp.isDarkMode ? ThemeMode.dark : ThemeMode.light;
 
     if (!_syncedOnce || modeFromPrefs != _themeMode) {
-      _syncedOnce = true;
       _themeMode = modeFromPrefs;
       notifyListeners();
     }
+    _syncedOnce = true;
   }
 
   Future<void> toggleTheme() async {


### PR DESCRIPTION
<!-- PR Template for Nourish App -->

## 📝 Description

Implement SharedPreferencesProvider for app settings (theme + language), refactor ThemeProvider to persist via SharedPreferencesProvider, preload settings at startup, and remove debug banner.

Includes a safe migration from legacy 'themeMode' (string) to new 'isDarkMode' (bool).

## ✅ Related Issue

Closes #3

## 🔍 Changes Made

- Added `SharedPreferencesProvider` with:
  - `isDarkMode` and `preferredLanguage` persistence
  - Cached `SharedPreferences` instance
  - `initialized` flag to avoid flicker
  - Migration from legacy `themeMode` key to `isDarkMode`
- Refactored `ThemeProvider` to read/write theme via `SharedPreferencesProvider` (single source of truth)
- Wired providers with `ChangeNotifierProxyProvider` in `providers.dart`
- Preloaded `SharedPreferencesProvider` in `main.dart` before `runApp`, then provided it first in the tree
- Bound `MaterialApp.themeMode` to `ThemeProvider` and `locale` to `SharedPreferencesProvider`
- Added `supportedLocales: const [Locale('en')]` (baseline for future localization)
- Removed the debug banner (`debugShowCheckedModeBanner: false`)

Files touched:
- lib/providers/shared_preferences_provider.dart
- lib/providers/theme_provider.dart
- lib/providers.dart
- lib/main.dart

## 📸 Screenshots (if applicable)

N/A (no UI changes introduced)

---

> 🫶 Thank you for contributing to Nourish!