### PR TITLE
feat: Add calendar view for food log date [Closes #33]

### DIFF
--- a/lib/screens/add_meal/add_meal_view.dart
+++ b/lib/screens/add_meal/add_meal_view.dart
@@ -10,18 +10,274 @@ class AddMealView extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => AddMealViewModel(),
-      child: Consumer<AddMealViewModel>(
-        builder: (context, model, child) {
-          return Scaffold(
-            body: Center(
-              child: ElevatedButton(
-                onPressed: () => context.go('/ai_recipes'),
-                child: Text('Go to AI Recipes'),
-              ),
-            ),
-          );
-        },
+      child: const _AddMealBody(),
+    );
+  }
+}
+
+class _AddMealBody extends StatefulWidget {
+  const _AddMealBody();
+
+  @override
+  State<_AddMealBody> createState() => _AddMealBodyState();
+}
+
+class _AddMealBodyState extends State<_AddMealBody> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _caloriesController = TextEditingController();
+  final _proteinController = TextEditingController();
+  final _carbsController = TextEditingController();
+  final _fatsController = TextEditingController();
+  String _selectedMealType = 'Breakfast';
+
+  final List<Map<String, dynamic>> _mealTypes = [
+    {'label': 'Breakfast', 'icon': Icons.wb_sunny_outlined},
+    {'label': 'Lunch', 'icon': Icons.light_mode_outlined},
+    {'label': 'Dinner', 'icon': Icons.nightlight_outlined},
+    {'label': 'Snack', 'icon': Icons.cookie_outlined},
+  ];
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _caloriesController.dispose();
+    _proteinController.dispose();
+    _carbsController.dispose();
+    _fatsController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('${_nameController.text} added to $_selectedMealType!'),
+          backgroundColor: Theme.of(context).colorScheme.primary,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      );
+      context.go('/food_log');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        title: const Text(
+          'Add Meal',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/food_log'),
+        ),
       ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Meal Type',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+              ),
+              const SizedBox(height: 10),
+              Row(
+                children:
+                    _mealTypes.map((type) {
+                      final selected = _selectedMealType == type['label'];
+                      return Expanded(
+                        child: GestureDetector(
+                          onTap:
+                              () => setState(
+                                () => _selectedMealType = type['label'],
+                              ),
+                          child: Container(
+                            margin: const EdgeInsets.only(right: 8),
+                            padding: const EdgeInsets.symmetric(vertical: 12),
+                            decoration: BoxDecoration(
+                              color:
+                                  selected
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Theme.of(context)
+                                          .colorScheme
+                                          .primaryContainer
+                                          .withOpacity(0.4),
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            child: Column(
+                              children: [
+                                Icon(
+                                  type['icon'] as IconData,
+                                  color:
+                                      selected
+                                          ? Colors.white
+                                          : Theme.of(
+                                            context,
+                                          ).colorScheme.primary,
+                                  size: 20,
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  type['label'],
+                                  style: TextStyle(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w600,
+                                    color:
+                                        selected
+                                            ? Colors.white
+                                            : Theme.of(
+                                              context,
+                                            ).colorScheme.primary,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    }).toList(),
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                'Food Name',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  hintText: 'e.g. Chicken Rice',
+                  prefixIcon: const Icon(Icons.restaurant_outlined),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  filled: true,
+                  fillColor: Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer.withOpacity(0.2),
+                ),
+                validator:
+                    (v) => v == null || v.isEmpty ? 'Enter food name' : null,
+              ),
+              const SizedBox(height: 20),
+              const Text(
+                'Calories',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+              ),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _caloriesController,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  hintText: 'kcal',
+                  prefixIcon: const Icon(Icons.local_fire_department_outlined),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  filled: true,
+                  fillColor: Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer.withOpacity(0.2),
+                ),
+                validator:
+                    (v) => v == null || v.isEmpty ? 'Enter calories' : null,
+              ),
+              const SizedBox(height: 20),
+              const Text(
+                'Macros',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: _MacroField(
+                      controller: _proteinController,
+                      label: 'Protein',
+                      color: Colors.blue,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: _MacroField(
+                      controller: _carbsController,
+                      label: 'Carbs',
+                      color: Colors.orange,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: _MacroField(
+                      controller: _fatsController,
+                      label: 'Fats',
+                      color: Colors.red,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 32),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                  child: const Text(
+                    'Add Meal',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MacroField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final Color color;
+
+  const _MacroField({
+    required this.controller,
+    required this.label,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      keyboardType: TextInputType.number,
+      decoration: InputDecoration(
+        labelText: '$label (g)',
+        labelStyle: TextStyle(color: color, fontSize: 12),
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(14)),
+        filled: true,
+        fillColor: color.withOpacity(0.08),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(color: color, width: 2),
+        ),
+      ),
+      validator: (v) => v == null || v.isEmpty ? 'Required' : null,
     );
   }
 }

--- a/lib/screens/food_log/calendar_view.dart
+++ b/lib/screens/food_log/calendar_view.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+class CalendarView extends StatefulWidget {
+  const CalendarView({super.key});
+
+  @override
+  State<CalendarView> createState() => _CalendarViewState();
+}
+
+class _CalendarViewState extends State<CalendarView> {
+  DateTime _focusedDay = DateTime.now();
+  DateTime _selectedDay = DateTime.now();
+  final Map<DateTime, List<String>> _meals = {
+    DateTime.utc(2026, 6, 5): ['Oats', 'Chicken Rice'],
+    DateTime.utc(2026, 6, 6): ['Banana Smoothie', 'Dal Chawal'],
+    DateTime.utc(2026, 6, 7): ['Eggs', 'Salad', 'Protein Shake'],
+  };
+
+  List<String> _getMealsForDay(DateTime day) {
+    return _meals[DateTime.utc(day.year, day.month, day.day)] ?? [];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mealsToday = _getMealsForDay(_selectedDay);
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        title: const Text(
+          'Food Log Calendar',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          Container(
+            margin: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Theme.of(
+                context,
+              ).colorScheme.primaryContainer.withOpacity(0.3),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: TableCalendar(
+              firstDay: DateTime.utc(2024, 1, 1),
+              lastDay: DateTime.utc(2030, 12, 31),
+              focusedDay: _focusedDay,
+              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+              eventLoader: _getMealsForDay,
+              calendarFormat: CalendarFormat.month,
+              startingDayOfWeek: StartingDayOfWeek.monday,
+              headerStyle: const HeaderStyle(
+                formatButtonVisible: false,
+                titleCentered: true,
+                titleTextStyle: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              calendarStyle: CalendarStyle(
+                selectedDecoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  shape: BoxShape.circle,
+                ),
+                todayDecoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary.withOpacity(0.4),
+                  shape: BoxShape.circle,
+                ),
+                markerDecoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.secondary,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              onDaySelected: (selectedDay, focusedDay) {
+                setState(() {
+                  _selectedDay = selectedDay;
+                  _focusedDay = focusedDay;
+                });
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.restaurant_menu,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '${_selectedDay.day}/${_selectedDay.month}/${_selectedDay.year}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+                Text(
+                  '${mealsToday.length} meals',
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(indent: 16, endIndent: 16),
+          Expanded(
+            child:
+                mealsToday.isEmpty
+                    ? Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.no_meals,
+                            size: 60,
+                            color: Colors.grey.shade400,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            'No meals logged',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.grey.shade500,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Tap + to add a meal',
+                            style: TextStyle(color: Colors.grey.shade400),
+                          ),
+                        ],
+                      ),
+                    )
+                    : ListView.builder(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      itemCount: mealsToday.length,
+                      itemBuilder: (context, index) {
+                        return Card(
+                          margin: const EdgeInsets.only(bottom: 10),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(14),
+                          ),
+                          child: ListTile(
+                            leading: CircleAvatar(
+                              backgroundColor:
+                                  Theme.of(
+                                    context,
+                                  ).colorScheme.primaryContainer,
+                              child: Text(
+                                '${index + 1}',
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                            title: Text(
+                              mealsToday[index],
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            subtitle: const Text('Tap to view details'),
+                            trailing: const Icon(Icons.chevron_right),
+                          ),
+                        );
+                      },
+                    ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Add meal coming soon!')),
+          );
+        },
+        icon: const Icon(Icons.add),
+        label: const Text('Add Meal'),
+      ),
+    );
+  }
+}

--- a/lib/screens/food_log/food_log_view.dart
+++ b/lib/screens/food_log/food_log_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:table_calendar/table_calendar.dart';
 import 'food_log_model.dart';
 
 class FoodLogView extends StatelessWidget {
@@ -10,18 +11,407 @@ class FoodLogView extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => FoodLogViewModel(),
-      child: Consumer<FoodLogViewModel>(
-        builder: (context, model, child) {
-          return Scaffold(
-            body: Center(
-              child: ElevatedButton(
-                onPressed: () => context.go('/add_meal'),
-                child: Text('Go to Add Meal'),
-              ),
-            ),
-          );
+      child: const _FoodLogBody(),
+    );
+  }
+}
+
+class _FoodLogBody extends StatefulWidget {
+  const _FoodLogBody();
+
+  @override
+  State<_FoodLogBody> createState() => _FoodLogBodyState();
+}
+
+class _FoodLogBodyState extends State<_FoodLogBody> {
+  DateTime _focusedDay = DateTime.now();
+  DateTime _selectedDay = DateTime.now();
+
+  final Map<DateTime, Map<String, List<Map<String, dynamic>>>> _allMeals = {
+    DateTime.utc(2026, 6, 7): {
+      'Breakfast': [
+        {'name': 'Eggs', 'cal': 140, 'protein': 12, 'carbs': 1, 'fats': 10},
+      ],
+      'Lunch': [
+        {'name': 'Salad', 'cal': 90, 'protein': 3, 'carbs': 12, 'fats': 4},
+      ],
+      'Dinner': [
+        {
+          'name': 'Protein Shake',
+          'cal': 180,
+          'protein': 25,
+          'carbs': 10,
+          'fats': 3,
         },
+      ],
+      'Snack': [],
+    },
+    DateTime.utc(2026, 6, 6): {
+      'Breakfast': [
+        {
+          'name': 'Banana Smoothie',
+          'cal': 200,
+          'protein': 4,
+          'carbs': 42,
+          'fats': 2,
+        },
+      ],
+      'Lunch': [
+        {
+          'name': 'Dal Chawal',
+          'cal': 380,
+          'protein': 14,
+          'carbs': 65,
+          'fats': 6,
+        },
+      ],
+      'Dinner': [],
+      'Snack': [],
+    },
+  };
+
+  static const List<String> _mealOrder = [
+    'Breakfast',
+    'Lunch',
+    'Dinner',
+    'Snack',
+  ];
+  static const Map<String, IconData> _mealIcons = {
+    'Breakfast': Icons.wb_sunny_outlined,
+    'Lunch': Icons.light_mode_outlined,
+    'Dinner': Icons.nightlight_outlined,
+    'Snack': Icons.cookie_outlined,
+  };
+
+  Map<String, List<Map<String, dynamic>>> _getMealsForDay(DateTime day) {
+    final key = DateTime.utc(day.year, day.month, day.day);
+    return _allMeals[key] ??
+        {'Breakfast': [], 'Lunch': [], 'Dinner': [], 'Snack': []};
+  }
+
+  List<Map<String, dynamic>> _flatList(DateTime day) {
+    final data = _getMealsForDay(day);
+    return data.values.expand((e) => e).toList();
+  }
+
+  int _totalCalories(DateTime day) {
+    return _flatList(day).fold(0, (sum, m) => sum + (m['cal'] as int));
+  }
+
+  void _showMealDetail(BuildContext context, Map<String, dynamic> meal) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
+      builder:
+          (_) => Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        meal['name'],
+                        style: const TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.primaryContainer,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        '${meal['cal']} kcal',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    _MacroTile('Protein', '${meal['protein']}g', Colors.blue),
+                    _MacroTile('Carbs', '${meal['carbs']}g', Colors.orange),
+                    _MacroTile('Fats', '${meal['fats']}g', Colors.red),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Close'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dayMeals = _getMealsForDay(_selectedDay);
+    final total = _totalCalories(_selectedDay);
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        title: const Text(
+          'Food Log',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          Container(
+            margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+            decoration: BoxDecoration(
+              color: Theme.of(
+                context,
+              ).colorScheme.primaryContainer.withOpacity(0.3),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: TableCalendar(
+              firstDay: DateTime.utc(2024, 1, 1),
+              lastDay: DateTime.utc(2030, 12, 31),
+              focusedDay: _focusedDay,
+              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+              eventLoader: (day) => _flatList(day),
+              calendarFormat: CalendarFormat.month,
+              startingDayOfWeek: StartingDayOfWeek.monday,
+              headerStyle: const HeaderStyle(
+                formatButtonVisible: false,
+                titleCentered: true,
+                titleTextStyle: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              calendarStyle: CalendarStyle(
+                selectedDecoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  shape: BoxShape.circle,
+                ),
+                todayDecoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary.withOpacity(0.4),
+                  shape: BoxShape.circle,
+                ),
+                markerDecoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.secondary,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              onDaySelected: (selectedDay, focusedDay) {
+                setState(() {
+                  _selectedDay = selectedDay;
+                  _focusedDay = focusedDay;
+                });
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.restaurant_menu,
+                  color: Theme.of(context).colorScheme.primary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '${_selectedDay.day}/${_selectedDay.month}/${_selectedDay.year}',
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    '$total kcal',
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(indent: 16, endIndent: 16),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              children:
+                  _mealOrder.map((mealType) {
+                    final items = dayMeals[mealType] ?? [];
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: Row(
+                            children: [
+                              Icon(
+                                _mealIcons[mealType],
+                                size: 18,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                mealType,
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 15,
+                                ),
+                              ),
+                              const Spacer(),
+                              Text(
+                                '${items.fold(0, (s, m) => s + (m['cal'] as int))} kcal',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Theme.of(context).colorScheme.primary,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        if (items.isEmpty)
+                          Container(
+                            margin: const EdgeInsets.only(bottom: 8),
+                            padding: const EdgeInsets.all(14),
+                            decoration: BoxDecoration(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.primaryContainer.withOpacity(0.2),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color:
+                                    Theme.of(
+                                      context,
+                                    ).colorScheme.primaryContainer,
+                                width: 1,
+                              ),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.add_circle_outline,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.primary.withOpacity(0.5),
+                                  size: 18,
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'No $mealType logged',
+                                  style: TextStyle(
+                                    color: Colors.grey.shade400,
+                                    fontSize: 13,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          )
+                        else
+                          ...items.map(
+                            (meal) => Card(
+                              margin: const EdgeInsets.only(bottom: 8),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(14),
+                              ),
+                              child: ListTile(
+                                leading: CircleAvatar(
+                                  backgroundColor:
+                                      Theme.of(
+                                        context,
+                                      ).colorScheme.primaryContainer,
+                                  child: Icon(
+                                    _mealIcons[mealType],
+                                    size: 16,
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
+                                  ),
+                                ),
+                                title: Text(
+                                  meal['name'],
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                subtitle: Text('${meal['cal']} kcal'),
+                                trailing: const Icon(Icons.chevron_right),
+                                onTap: () => _showMealDetail(context, meal),
+                              ),
+                            ),
+                          ),
+                        const Divider(),
+                      ],
+                    );
+                  }).toList(),
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.go('/add_meal'),
+        icon: const Icon(Icons.add),
+        label: const Text('Add Meal'),
+      ),
+    );
+  }
+}
+
+class _MacroTile extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color color;
+
+  const _MacroTile(this.label, this.value, this.color);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(label, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+      ],
     );
   }
 }

--- a/lib/screens/landing/landing_view.dart
+++ b/lib/screens/landing/landing_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'landing_model.dart';
+import 'package:provider/provider.dart';
 
 class LandingView extends StatelessWidget {
   const LandingView({super.key});
@@ -10,17 +10,152 @@ class LandingView extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => LandingViewModel(),
-      child: Consumer<LandingViewModel>(
-        builder: (context, model, child) {
-          return Scaffold(
-            body: Center(
-              child: ElevatedButton(
-                onPressed: () => context.go('/home'),
-                child: Text('Go to Home'),
+      child: Scaffold(
+        body: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                Theme.of(context).colorScheme.primaryContainer,
+                Theme.of(context).colorScheme.surface,
+              ],
+            ),
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 28),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Spacer(flex: 2),
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primary,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Icon(
+                      Icons.restaurant_menu,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      size: 40,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Nourish',
+                    style: TextStyle(
+                      fontSize: 48,
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Track your nutrition,\nachieve your goals.',
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withOpacity(0.7),
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 40),
+                  Row(
+                    children: [
+                      _FeatureChip(
+                        icon: Icons.track_changes,
+                        label: 'Track Macros',
+                      ),
+                      const SizedBox(width: 10),
+                      _FeatureChip(
+                        icon: Icons.qr_code_scanner,
+                        label: 'Scan Food',
+                      ),
+                      const SizedBox(width: 10),
+                      _FeatureChip(
+                        icon: Icons.auto_awesome,
+                        label: 'AI Recipes',
+                      ),
+                    ],
+                  ),
+                  const Spacer(flex: 3),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () => context.go('/home'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                      ),
+                      child: const Text(
+                        'Get Started',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton(
+                      onPressed: () => context.go('/food_log'),
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                      ),
+                      child: const Text(
+                        'View Food Log',
+                        style: TextStyle(fontSize: 16),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 40),
+                ],
               ),
             ),
-          );
-        },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _FeatureChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -472,6 +472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: ba2cd5af24ff20a0b8d609cec3f40e5b0744d2a71804a2616ae086b9c19d19a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -573,6 +581,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: "1e3521a3e6d3fc7f645a58b135ab663d458ab12504f1ea7f9b4b81d47086c478"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   font_awesome_flutter: ^10.9.0
   loading_animation_widget: ^1.3.0
   flutter_svg: ^2.2.1
+  table_calendar: 3.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📝 Description
[feat]: Added calendar view with meal type sections in food log

## ✅ Related Issue
Closes #33

## 🔍 Changes Made
- Created `lib/screens/food_log/calendar_view.dart`
- Added `table_calendar ^3.0.9` dependency
- Integrated calendar into `food_log_view.dart`
- Meal type sections — Breakfast, Lunch, Dinner, Snack
- Calorie count per meal type and total daily calories
- Tap on meal to see macro detail (protein, carbs, fats)

## 🧪 Testing
- [x] `flutter run` works without error
- [x] New/updated feature tested manually
- [ ] Relevant tests added
- [ ] Existing tests were updated

## 📦 Checklist
- [x] Follows code style and naming conventions
- [x] PR linked to a GitHub issue

## screenshots attached
<img width="1080" height="2400" alt="WhatsApp Image 2026-06-07 at 7 31 15 PM" src="https://github.com/user-attachments/assets/9a7e8a7a-3dc4-466e-8e41-15c052436fac" />
<img width="720" height="1600" alt="WhatsApp Image 2026-06-07 at 7 26 16 PM (1)" src="https://github.com/user-attachments/assets/d886d01d-1292-42c5-b965-7b84cc7a1aa4" />
<img width="720" height="1600" alt="WhatsApp Image 2026-06-07 at 7 26 16 PM" src="https://github.com/user-attachments/assets/b8fe97fa-02bf-43bf-b514-051f29a628f2" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/3acf9fc0-4acc-4cb1-8046-4f94367fa091" />
